### PR TITLE
changed to ChunkVault name & fixed versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "teller"
-version = "0.1.0"
+version = "0.1.0-alpha.5"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -4029,7 +4029,7 @@ dependencies = [
 
 [[package]]
 name = "teller_desktop"
-version = "0.1.0"
+version = "0.1.0-alpha.5"
 dependencies = [
  "anyhow",
  "base64 0.21.2",

--- a/teller/Cargo.toml
+++ b/teller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teller"
-version = "0.1.0"
+version = "0.1.0-alpha.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/teller_desktop/src-tauri/Cargo.toml
+++ b/teller_desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teller_desktop"
-version = "0.1.0"
+version = "0.1.0-alpha.5"
 description = "Teller is a Minecraft world backup tool, for use with the ChunkVault ecosystem."
 authors = ["Valink Solutions"]
 license = ""

--- a/teller_desktop/src-tauri/tauri.conf.json
+++ b/teller_desktop/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
 		"distDir": "../build"
 	},
 	"package": {
-		"productName": "ChunkVault App"
+		"productName": "ChunkVault"
 	},
 	"tauri": {
 		"allowlist": {
@@ -71,7 +71,7 @@
 			{
 				"fullscreen": false,
 				"resizable": true,
-				"title": "ChunkVault App",
+				"title": "ChunkVault",
 				"minHeight": 720,
 				"minWidth": 1080
 			}


### PR DESCRIPTION
This makes sure the naming and versioning of the application follow the same rules so teller and teller_desktop are on 0.1.0-alpha.5 which will be the next release, meaning any pr requests need to update this version number to follow the correct naming convention, real features will do 0.1.1-alpha and then breaking changes will obviously do 0.2.0-alpha.