### PR TITLE
added 0.1.0.5 to indicate alpha version to fix

### DIFF
--- a/teller_desktop/src-tauri/tauri.conf.json
+++ b/teller_desktop/src-tauri/tauri.conf.json
@@ -7,7 +7,8 @@
 		"distDir": "../build"
 	},
 	"package": {
-		"productName": "ChunkVault"
+		"productName": "ChunkVault",
+		"version": "0.1.0.5"
 	},
 	"tauri": {
 		"allowlist": {


### PR DESCRIPTION
new versioning for tauri as windows builds are finicky, they demand a numerical only version so 0.1.0.5 indicates that its still the 0.1.0-alpha.5 but removing the alpha as it ruins windows builds, i will be updating the contribution file to account for these changes in versioning, I would like to apologize to anyone that comes across these and thinks they are the workings of a mad man, They are.