### PR TITLE
reverted versioning, linked to contribute guide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "teller"
-version = "0.1.0-alpha.5"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -4029,7 +4029,7 @@ dependencies = [
 
 [[package]]
 name = "teller_desktop"
-version = "0.1.0-alpha.5"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.21.2",

--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ While Teller and Teller_Desktop handle the backup process, [The Vault Backend](h
 
 This project is licensed under the [GNU General Public License v3.0](LICENSE.txt).
 
+# Contributing
+
+Follow the [contributing guidelines](https://docs.chunkvault.com/teller/contributing/) to contribute to this project.
+
 # Shoutout
 
 A special shoutout to the development team behind [Modrinth's Theseus Minecraft Launcher](https://github.com/modrinth/theseus). We've modeled our application setup/structure after theirs, as it is both easy to follow and use. Their work has greatly influenced the development of Teller and we appreciate their contribution to the Minecraft community, as well as their support of open-source software.
-
 

--- a/teller/Cargo.toml
+++ b/teller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teller"
-version = "0.1.0-alpha.5"
+version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/teller_desktop/src-tauri/Cargo.toml
+++ b/teller_desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teller_desktop"
-version = "0.1.0-alpha.5"
+version = "0.1.0"
 description = "Teller is a Minecraft world backup tool, for use with the ChunkVault ecosystem."
 authors = ["Valink Solutions"]
 license = ""

--- a/teller_desktop/src-tauri/tauri.conf.json
+++ b/teller_desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
 	},
 	"package": {
 		"productName": "ChunkVault",
-		"version": "0.1.0.5"
+		"version": "0.1.0"
 	},
 	"tauri": {
 		"allowlist": {


### PR DESCRIPTION
After this PR I am not touching ChunkVault for a bit, as i have collapsed my mind on my versioning, I guess this is why most tauri applications are purely 0.1.0 not including -alpha, i apologize again to any community members, i promise this is not how i will act in the future and promise to better myself.